### PR TITLE
Derive serde Serialize and Deserialize

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Check formatting
+      run: make fmt-check
     - name: Build Rust
       run: make build
     - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,11 @@ axum-test = "17"
 fake = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[features]
+default = ["serde"]
+
+# Derives `serde::{Serialize, Deserialize}`.
+# `serde` is already present in the dependency tree. Adding this as a feature
+# in-case we can remove it in the future.
+serde = []

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "  test (t)          	- Run tests with all features"
 	@echo "  clippy (lint)     	- Run Clippy on the workspace"
 	@echo "  fmt              	- Format the project using nightly"
+	@echo "  fmt-check         	- Checks if the codebase is formatted correctly"
 	@echo "  doc (d)     	  	- Build the docs"
 
 # Development group
@@ -26,6 +27,10 @@ clippy lint:
 .PHONY: fmt
 fmt:
 	cargo +nightly fmt
+
+.PHONY: fmt-check
+fmt-check:
+	cargo fmt --check
 
 .PHONY: doc d
 doc d:

--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ struct RouteParams {
 ## Potential Improvements
 
 - Enable compile-time validation of routes and parameters for even greater safety.
+
+## Prior Art
+
+- [`TypedPath`](https://docs.rs/axum-extra/latest/axum_extra/routing/trait.TypedPath.html): The [`axum-extra`](https://docs.rs/axum-extra/latest/axum_extra) crate provides the `TypedPath` trait with a `#[derive(TypedPath)]` implementation. It enables type-safe, compile-time-checked population of path parameters and returns a [`Uri`](https://docs.rs/http/latest/http/uri/struct.Uri.html) suitable for use in requests. However, it does not appear to offer a clean or ergonomic way to **compose or join** multiple routes.

--- a/src/web_route.rs
+++ b/src/web_route.rs
@@ -1,8 +1,12 @@
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::{
     error::WebRouteError, segment::Segment, to_segments::ToSegments, utils::struct_to_map,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct WebRoute {
     segments: Vec<Segment>,
 }
@@ -116,5 +120,33 @@ impl WebRoute {
 
     pub(crate) fn segments(&self) -> Vec<Segment> {
         self.segments.clone()
+    }
+}
+
+impl fmt::Debug for WebRoute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("WebRoute")
+            .field(&self.as_template_route())
+            .finish()
+    }
+}
+
+impl Serialize for WebRoute {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = self.as_template_route();
+        serializer.serialize_str(&s)
+    }
+}
+
+impl<'de> Deserialize<'de> for WebRoute {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(WebRoute::new(s))
     }
 }

--- a/src/web_route.rs
+++ b/src/web_route.rs
@@ -131,6 +131,7 @@ impl fmt::Debug for WebRoute {
     }
 }
 
+#[cfg(feature = "serde")]
 impl Serialize for WebRoute {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -141,6 +142,7 @@ impl Serialize for WebRoute {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for WebRoute {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/tests/axum_path_extractor.rs
+++ b/tests/axum_path_extractor.rs
@@ -1,0 +1,45 @@
+//! Ensures that a [`WebRoute`] can be extracted by an `axum` [`Path`] path extractor.
+
+use std::cell::LazyCell;
+
+use axum::{Json, Router, extract::Path, routing::get};
+use web_route::WebRoute;
+
+// Would be cool if we could make this able to be evaluated at compile time so
+// that this can be a const without `LazyCell`.
+const ROUTE_WITH_PATH: LazyCell<WebRoute> = LazyCell::new(|| WebRoute::new("/foo/{*path}"));
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct RouteParams {
+    path: WebRoute,
+}
+
+async fn route_handler(Path(params): Path<RouteParams>) -> Json<RouteParams> {
+    Json(params)
+}
+
+fn build_router() -> Router {
+    Router::new().route(&ROUTE_WITH_PATH.as_template_route(), get(route_handler))
+}
+
+#[tokio::test]
+async fn should_be_able_to_extract_a_web_route_with_axum_path_extractor() {
+    // Arrange
+    let path_params = RouteParams {
+        path: WebRoute::new("another/route"),
+    };
+
+    let test_server = axum_test::TestServer::new(build_router()).unwrap();
+
+    // Act
+    let response = test_server
+        .get(
+            // Using `WebRoute` to build a route with the parameters populated.
+            &ROUTE_WITH_PATH.as_populated_route(&path_params).unwrap(),
+        )
+        .await;
+
+    // Assert
+    let parsed_body = response.json::<RouteParams>();
+    assert_eq!(parsed_body, path_params);
+}


### PR DESCRIPTION
Derive `serde` Serialize and Deserialize. A `WebRoute` can now be extracted with an [`axum` `Path` extractor](https://docs.rs/axum/latest/axum/extract/struct.Path.html).