### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/sidrubs/web-route/compare/v0.1.0...v0.1.1) - 2025-06-09
+
+### Added
+
+- *(serde)* Implement serde Serialize and Deserialize for WebRoute

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "web-route"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-route"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Ergonomic web route construction, joining, and population for Rust web frameworks"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `web-route`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/sidrubs/web-route/compare/v0.1.0...v0.1.1) - 2025-06-09

### Added

- *(serde)* Implement serde Serialize and Deserialize for WebRoute
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).