### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/sidrubs/web-route/compare/v0.1.1...v0.1.2) - 2025-06-10
+
+### Other
+
+- Untrack Cargo.lock ([#4](https://github.com/sidrubs/web-route/pull/4))
+
 ## [0.1.1](https://github.com/sidrubs/web-route/compare/v0.1.0...v0.1.1) - 2025-06-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-route"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Ergonomic web route construction, joining, and population for Rust web frameworks"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `web-route`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/sidrubs/web-route/compare/v0.1.1...v0.1.2) - 2025-06-10

### Other

- Untrack Cargo.lock ([#4](https://github.com/sidrubs/web-route/pull/4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).