### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/sidrubs/web-route/compare/v0.2.0...v0.2.1) - 2025-07-10
+
+### Other
+
+- Convert internal representation to String ([#7](https://github.com/sidrubs/web-route/pull/7))
+
 ## [0.2.0](https://github.com/sidrubs/web-route/compare/v0.1.1...v0.2.0) - 2025-06-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-route"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Ergonomic web route construction, joining, and population for Rust web frameworks"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `web-route`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/sidrubs/web-route/compare/v0.2.0...v0.2.1) - 2025-07-10

### Other

- Convert internal representation to String ([#7](https://github.com/sidrubs/web-route/pull/7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).