### PR TITLE
Feat: Implement `fake::Dummy` for `WebRoute` and `ParameterizedRoute`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ serde = "1"
 serde_json = "1"
 thiserror = "2"
 
+# `fake` feature deps
+fake = { version = "4", optional = true }
+
 [dev-dependencies]
 axum = "0.8"
 axum-test = "17"
@@ -24,7 +27,8 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [features]
-default = ["serde"]
+default = ["serde", "fake"]
+fake = ["dep:fake"]
 
 # Derives `serde::{Serialize, Deserialize}`.
 # `serde` is already present in the dependency tree. Adding this as a feature

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Most web frameworks define routes using `&str` templates (e.g. `"/foo/{param}"`)
 
 ## Usage
 
-One can create and join [`WebRoute`]s without having to worry about leading and trailing slash pedantics. The resulting routes will always be normalized to have single forward slash separators no matter the operating system.
+One can create and join [`WebRoute`][]s without having to worry about leading and trailing slash pedantics. The resulting routes will always be normalized to have single forward slash separators no matter the operating system.
 
 ```rust
 use web_route::WebRoute;
@@ -33,7 +33,7 @@ let joined_route = foo.join("/a/str/route");
 assert_eq!(&joined_route.to_string(), "/no/leading/slash/a/str/route");
 ```
 
-[`WebRoute`]s can be serialized and deserialized.
+[`WebRoute`][]s can be serialized and deserialized.
 
 ```rust
 use serde::{Serialize, Deserialize};
@@ -65,7 +65,7 @@ let bar = ParameterizedRoute::new("/bar/{bar_id}");
 assert_eq!(&foo.join(bar).to_string(), "/foo/{foo_id}/bar/{bar_id}");
 ```
 
-A [`ParameterizedRoute`][] can be populated with values to produce a [`WebRoute`] which can then be used to make a request to the server route it defines.
+A [`ParameterizedRoute`][] can be populated with values to produce a [`WebRoute`][] which can then be used to make a request to the server route it defines.
 
 ```rust
 use serde::{Serialize, Deserialize};
@@ -92,7 +92,6 @@ assert_eq!(&web_route.to_string(), "/foo/value_foo/bar/value_bar");
 
 For more complete examples, see the [examples](https://github.com/sidrubs/web-route/tree/main/examples) and [integration tests](https://github.com/sidrubs/web-route/tree/main/tests).
 
-
 ## Potential Improvements
 
 - Enable compile-time validation of routes and parameters for even greater safety.
@@ -100,6 +99,10 @@ For more complete examples, see the [examples](https://github.com/sidrubs/web-ro
 ## Prior Art
 
 - [`TypedPath`](https://docs.rs/axum-extra/latest/axum_extra/routing/trait.TypedPath.html): The [`axum-extra`](https://docs.rs/axum-extra/latest/axum_extra) crate provides the `TypedPath` trait with a `#[derive(TypedPath)]` implementation. It enables type-safe, compile-time-checked population of path parameters and returns a [`Uri`](https://docs.rs/http/latest/http/uri/struct.Uri.html) suitable for use in requests. However, it does not appear to offer a clean or ergonomic way to **compose or join** multiple routes.
+
+## Feature Flags
+
+- `fake`: Implements [`fake::Dummy`](https://docs.rs/fake/latest/fake/trait.Dummy.html) on [`WebRoute`][] and [`ParameterizedRoute`][].
 
 [`WebRoute`]: ./src/web_route/route.rs
 [`ParameterizedRoute`]: ./src/parameterized_route/route.rs

--- a/src/parameterized_route/route.rs
+++ b/src/parameterized_route/route.rs
@@ -126,6 +126,16 @@ impl ops::Deref for ParameterizedRoute {
     }
 }
 
+#[cfg(feature = "fake")]
+impl fake::Dummy<fake::Faker> for ParameterizedRoute {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        use fake::Fake;
+
+        let segments: Vec<ParameterizedSegment> = config.fake_with_rng(rng);
+        Self::new(segments)
+    }
+}
+
 /// Convert `segments` into their normalized [`String`] route representation.
 fn evaluate_segments(segments: Vec<ParameterizedSegment>) -> String {
     let evaluated_segments = segments

--- a/src/parameterized_route/segment.rs
+++ b/src/parameterized_route/segment.rs
@@ -7,6 +7,7 @@ use crate::{error::WebRouteError, web_route::segment::WebSegment};
 /// Handles converting it between the templated representation of the segment,
 /// and the populated version.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "fake", derive(fake::Dummy))]
 pub enum ParameterizedSegment {
     NamedParam(String),
     CatchallParam(String),

--- a/src/to_segments.rs
+++ b/src/to_segments.rs
@@ -58,6 +58,13 @@ impl ToFixedSegments for LazyLock<WebRoute> {
     }
 }
 
+#[cfg(feature = "fake")]
+impl ToFixedSegments for Vec<WebSegment> {
+    fn to_segments(&self) -> Vec<WebSegment> {
+        self.clone()
+    }
+}
+
 pub trait ToParameterizedSegments {
     /// Defines how to convert something into a [`Vec`] of
     /// [`ParameterizedSegment`]s.
@@ -146,6 +153,13 @@ impl ToParameterizedSegments for LazyLock<WebRoute> {
             .into_iter()
             .map(Into::into)
             .collect()
+    }
+}
+
+#[cfg(feature = "fake")]
+impl ToParameterizedSegments for Vec<ParameterizedSegment> {
+    fn to_segments(&self) -> Vec<ParameterizedSegment> {
+        self.clone()
     }
 }
 

--- a/src/web_route/route.rs
+++ b/src/web_route/route.rs
@@ -93,6 +93,16 @@ impl ops::Deref for WebRoute {
     }
 }
 
+#[cfg(feature = "fake")]
+impl fake::Dummy<fake::Faker> for WebRoute {
+    fn dummy_with_rng<R: fake::Rng + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        use fake::Fake;
+
+        let segments: Vec<WebSegment> = config.fake_with_rng(rng);
+        Self::new(segments)
+    }
+}
+
 /// Convert `segments` into their normalized [`String`] route representation.
 fn evaluate_segments(segments: Vec<WebSegment>) -> String {
     let evaluated_segments = segments

--- a/src/web_route/segment.rs
+++ b/src/web_route/segment.rs
@@ -1,5 +1,6 @@
 /// Represents an individual segment of a route (i.e. the bit between the `/`).
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "fake", derive(fake::Dummy))]
 pub struct WebSegment(String);
 
 impl WebSegment {


### PR DESCRIPTION
Implemented behind the `fake` feature flag