### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/sidrubs/web-route/compare/v0.2.2...v0.2.3) - 2025-07-22
+
+### Added
+
+- Implement `fake::Dummy` for `WebRoute` and `ParameterizedRoute` ([#11](https://github.com/sidrubs/web-route/pull/11))
+
 ## [0.2.2](https://github.com/sidrubs/web-route/compare/v0.2.1...v0.2.2) - 2025-07-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-route"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "Ergonomic web route construction, joining, and population for Rust web frameworks"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `web-route`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/sidrubs/web-route/compare/v0.2.2...v0.2.3) - 2025-07-22

### Added

- Implement `fake::Dummy` for `WebRoute` and `ParameterizedRoute` ([#11](https://github.com/sidrubs/web-route/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).