### PR TITLE
Add support for joining UUIDs on `WebRoutes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /target
-
 Cargo.lock
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ thiserror = "2"
 # `fake` feature deps
 fake = { version = "4", optional = true, features = ["derive"] }
 
+# `uuid` feature deps
+uuid = { version = "1", optional = true }
+
 [dev-dependencies]
 axum = "0.8"
 axum-test = "18"
@@ -29,6 +32,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 [features]
 default = ["serde"]
 fake = ["dep:fake"]
+uuid = ["dep:uuid"]
 
 # Derives `serde::{Serialize, Deserialize}`.
 # `serde` is already present in the dependency tree. Adding this as a feature

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ For more complete examples, see the [examples](https://github.com/sidrubs/web-ro
 ## Feature Flags
 
 - `fake`: Implements [`fake::Dummy`](https://docs.rs/fake/latest/fake/trait.Dummy.html) on [`WebRoute`][] and [`ParameterizedRoute`][].
+- `uuid`: Enables support for [`uuid::Uuid`] so they can be directly joined on a [`WebRoute`][] or [`ParameterizedRoute`][]
 
 [`WebRoute`]: ./src/web_route/route.rs
 [`ParameterizedRoute`]: ./src/parameterized_route/route.rs
+[`uuid::Uuid`]: https://docs.rs/uuid/latest/uuid/struct.Uuid.html

--- a/src/parameterized_route/segment.rs
+++ b/src/parameterized_route/segment.rs
@@ -82,6 +82,13 @@ impl From<WebSegment> for ParameterizedSegment {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl From<uuid::Uuid> for ParameterizedSegment {
+    fn from(value: uuid::Uuid) -> Self {
+        Self::Static(value.to_string())
+    }
+}
+
 #[cfg(test)]
 mod segment_tests {
     use super::*;
@@ -158,6 +165,23 @@ mod segment_tests {
 
             // Assert
             assert!(matches!(segment, ParameterizedSegment::Static(value) if value == "static"));
+        }
+
+        #[cfg(feature = "uuid")]
+        #[test]
+        fn should_parse_uuid() {
+            // Arrange
+            let hyphenated_uuid_str = "aea4d73f-5762-408f-b5ae-d0899c8fe83a";
+            let sample_uuid =
+                uuid::Uuid::parse_str(hyphenated_uuid_str).expect("should parse valid UUID");
+
+            // Act
+            let segment = ParameterizedSegment::from(sample_uuid);
+
+            // Assert
+            assert!(
+                matches!(segment, ParameterizedSegment::Static(value) if value == hyphenated_uuid_str)
+            );
         }
 
         #[test]

--- a/src/to_segments.rs
+++ b/src/to_segments.rs
@@ -58,6 +58,13 @@ impl ToFixedSegments for LazyLock<WebRoute> {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl ToFixedSegments for uuid::Uuid {
+    fn to_segments(&self) -> Vec<WebSegment> {
+        vec![WebSegment::from(*self)]
+    }
+}
+
 #[cfg(feature = "fake")]
 impl ToFixedSegments for Vec<WebSegment> {
     fn to_segments(&self) -> Vec<WebSegment> {
@@ -153,6 +160,13 @@ impl ToParameterizedSegments for LazyLock<WebRoute> {
             .into_iter()
             .map(Into::into)
             .collect()
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl ToParameterizedSegments for uuid::Uuid {
+    fn to_segments(&self) -> Vec<ParameterizedSegment> {
+        vec![ParameterizedSegment::from(*self)]
     }
 }
 

--- a/src/web_route/route.rs
+++ b/src/web_route/route.rs
@@ -118,3 +118,36 @@ fn evaluate_segments(segments: Vec<WebSegment>) -> String {
 
     format!("/{}", evaluated_segments.join("/"))
 }
+
+#[cfg(test)]
+mod join_tests {
+    use fake::{Fake, Faker};
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn uuids_are_joined_with_hyphenated_string_representation() {
+        // Arrange
+        let base_route = Faker.fake::<crate::WebRoute>();
+        let hyphenated_uuid_str = "9a878802-7b0f-4531-bcbb-9a88d4324a5f";
+        let sample_uuid =
+            uuid::Uuid::parse_str(hyphenated_uuid_str).expect("should parse valid UUID");
+
+        // Act
+        let new_route = base_route.join(sample_uuid);
+        let segments = new_route.to_segments();
+        let (last_segment, original_segments) =
+            segments.split_last().expect("segments should not be empty");
+
+        // Assert
+        assert_eq!(
+            last_segment.to_evaluated(),
+            hyphenated_uuid_str.to_owned(),
+            "joined UUID should be the final segment"
+        );
+        assert_eq!(
+            original_segments,
+            &base_route.to_segments(),
+            "original segments should not be modified"
+        );
+    }
+}

--- a/src/web_route/segment.rs
+++ b/src/web_route/segment.rs
@@ -22,3 +22,10 @@ impl TryFrom<&str> for WebSegment {
         }
     }
 }
+
+#[cfg(feature = "uuid")]
+impl From<uuid::Uuid> for WebSegment {
+    fn from(value: uuid::Uuid) -> Self {
+        Self(value.to_string())
+    }
+}


### PR DESCRIPTION
## Summary

**Optional feature** to enable the ability to join/append a single `uuid::Uuid` to a `WebRoute` without first converting it to a `String`, or to fallibly attempt to resolve it as part of a `ParameterizedRoute`.

## Motivation

Proposed due to the common operation of taking a route like:

```rust
"/api/v1/users"
```

and simply append an ID to form:

```rust
"/api/v1/users/ed8c7a7c-8be6-49d7-9bf6-b96d0f407b14"
```

## More Details

Though this could additionally be represented as a `ParameterizedRoute` (e.g. `"/api/v1/users/{id}"`), this optional feature may provide some ergonomic convenience for "one-off" paths that one may wish to construct infallibly. 

An example:

```rust

// Prior Approach A: Create parameterized route (fallible)
let user_id = uuid::Uuid::new_v4();
let parameterized_route = ParameterizedRoute::new("/api/users/{user_id}");
let web_route = parameterized_route
    .to_web_route(&json!(
        {"user_id": user_id}
    ))
    .unwrap();

// Prior Approach B: Join as string (infallible)
let user_id = uuid::Uuid::new_v4();
let web_route = WebRoute::new("/api/users");
let web_route = web_route.join(user_id.to_string());

// New Approach: Join as `uuid::Uuid`
let user_id = uuid::Uuid::new_v4();
let web_route = WebRoute::new("/api/users");
let web_route = web_route.join(user_id);

```

Recognizing that this may not be everyone's cup of tea, this behaviour was added behind the `uuid` feature, which is disabled by default.